### PR TITLE
Return to noarch build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: fa926f869d70e0d652c005661948cd0c7fee5508ae17d437937f34f5287590b3
 
 build:
-  number: 1
+  noarch: python
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -20,7 +21,7 @@ requirements:
     - setuptools_scm
   run:
     - python
-    - importlib-metadata >=1.5  # [py<38]
+    - importlib-metadata >=1.5
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,11 +16,11 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
     - setuptools_scm
   run:
-    - python
+    - python >=3.7
     - importlib-metadata >=1.5
 
 test:


### PR DESCRIPTION
We used different Python version builds because importlib-metadata is only required for Python 3.7 and lower. However, the advantages of noarch are big enough that it's worth "unnecessarily" depending on importlib-metadata in newer Python in order to avoid arch-specific builds. (e.g. there are no native Apple Silicon builds of napari-plugin-engine at the moment.) Once Python 3.7 is dropped from conda-forge, we can drop the dependency.
